### PR TITLE
'Customs' imports moved above bootstrap imports

### DIFF
--- a/public_html/assets/scss/app.scss
+++ b/public_html/assets/scss/app.scss
@@ -10,6 +10,22 @@
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 */
 
+// Customs
+@import "abstracts/colors";
+@import "abstracts/variables";
+@import "abstracts/mixins";
+
+@import "base/typography";
+@import "base/base";
+@import "base/animations";
+@import "base/utilities";
+
+@import "components/table";
+
+@import "layouts/section";
+
+@import "pages/home";
+
 // Bootstrap 4.3
 @import "vendors/bootstrap4.3/functions";
 @import "vendors/bootstrap4.3/variables";
@@ -48,19 +64,3 @@
 @import "vendors/bootstrap4.3/spinners";
 @import "vendors/bootstrap4.3/utilities";
 @import "vendors/bootstrap4.3/print";
-
-// Customs
-@import "abstracts/colors";
-@import "abstracts/variables";
-@import "abstracts/mixins";
-
-@import "base/typography";
-@import "base/base";
-@import "base/animations";
-@import "base/utilities";
-
-@import "components/table";
-
-@import "layouts/section";
-
-@import "pages/home";


### PR DESCRIPTION
Hi, and thank you for this great tool!
I tried to play around with Bootstrap theming putting variable overrides in `public_html/assets/scss/abstracts/_variables.scss` and almost all of them didn't work.
Here's what I found to fix the problem:

When overriding bootstrap variables across Sass files, the overrides must come before Bootstrap’s Sass files imports.
https://getbootstrap.com/docs/4.3/getting-started/theming/#variable-defaults